### PR TITLE
Fixing "You cannot serialize or unserialize PDO instances" when serializing the query object

### DIFF
--- a/Query.php
+++ b/Query.php
@@ -1990,4 +1990,23 @@ class Query implements QueryInterface, PreparableInterface
 
 		return $this;
 	}
+
+	/**
+	 * Unsetting PDO connection before going to sleep (this is needed if the query gets serialized)
+	 */
+	public function __sleep()
+	{
+		$this->connection = NULL;
+	}
+
+	/**
+	 * Trying to re-retrieve the pdo connection after waking up
+	 */
+	public function __wakeup()
+	{
+		if ($this->name)
+		{
+			$this->connection = ConnectionContainer::getConnection($this->name);
+		}
+	}
 }


### PR DESCRIPTION
I am experiencing a pdo exception "You cannot serialize or unserialize PDO instances" when i want to serialize the query object, this should be fixed by unsetting the ->connection member.
